### PR TITLE
Rename WP_Customize_Postmeta_Setting to Custom_CSS_Per_Post_Postmeta_Customize_Setting

### DIFF
--- a/class-custom-css-per-post-postmeta-setting.php
+++ b/class-custom-css-per-post-postmeta-setting.php
@@ -3,7 +3,7 @@
  * A class for postmeta Customizer Setting, because existing filters
  * inside of WP_Customize_Setting are not substantial enough, namely `customize_value_*`.
  */
-class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
+class Custom_CSS_Per_Post_Postmeta_Customize_Setting extends WP_Customize_Setting {
 	/**
 	 * Utility function to extract the post ID from the id data.
 	 */

--- a/index.php
+++ b/index.php
@@ -23,7 +23,7 @@ add_action( 'wp_head', function() {
  */
 add_action( 'customize_register', function() {
 	global $wp_customize;
-	require_once( plugin_dir_path( __FILE__ ) . 'class-wp-customize-postmeta-setting.php' );
+	require_once( plugin_dir_path( __FILE__ ) . 'class-custom-css-per-post-postmeta-setting.php' );
 } );
 
 /**
@@ -104,7 +104,7 @@ add_action( 'customize_register', function( $manager ) {
 		}
 	}
 
-	$setting = new WP_Customize_Postmeta_Setting(
+	$setting = new Custom_CSS_Per_Post_Postmeta_Customize_Setting(
 		$wp_customize,
 		sprintf( 'post[%d][meta][custom_css]', $post_id ),
 		array(


### PR DESCRIPTION
Fixes conflict with generic class name in [Customize Posts](https://github.com/xwp/wp-customize-posts).
